### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Alarm.php
+++ b/lib/Horde/Alarm.php
@@ -21,6 +21,7 @@
  * @license   http://www.horde.org/licenses/lgpl21 LGPL-2.1
  * @package   Alarm
  */
+#[\AllowDynamicProperties]
 abstract class Horde_Alarm
 {
     /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Alarm/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Alarm/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Alarm Unit Test">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Alarm/HandlerTest.php
+++ b/test/Horde/Alarm/HandlerTest.php
@@ -7,13 +7,13 @@
  * @subpackage UnitTests
  */
 
-class Horde_Alarm_HandlerTest extends PHPUnit_Framework_TestCase
+class Horde_Alarm_HandlerTest extends Horde_Test_Case
 {
     protected static $alarm;
     protected static $storage;
     protected static $mail;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('Horde_Notification')) {
             $this->markTestSkipped('Horde_Notification not installed');

--- a/test/Horde/Alarm/Storage/Base.php
+++ b/test/Horde/Alarm/Storage/Base.php
@@ -12,7 +12,7 @@ abstract class Horde_Alarm_Storage_Base extends Horde_Test_Case
     protected static $date;
     protected static $end;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $now = time();
         self::$date = new Horde_Date($now);
@@ -34,6 +34,7 @@ abstract class Horde_Alarm_Storage_Base extends Horde_Test_Case
                       'params' => array('foo' => str_repeat('X', 5000)),
                       'title' => 'This is a personal alarm.');
         self::$alarm->set($hash);
+        $this->assertIsObject(self::$alarm);
     }
 
     /**
@@ -50,7 +51,7 @@ abstract class Horde_Alarm_Storage_Base extends Horde_Test_Case
     public function testGet()
     {
         $alarm = self::$alarm->get('personalalarm', 'john');
-        $this->assertInternalType('array', $alarm);
+        $this->assertIsArray($alarm);
         $this->assertEquals('personalalarm', $alarm['id']);
         $this->assertEquals('john', $alarm['user']);
         $this->assertEquals(array(), $alarm['methods']);
@@ -72,6 +73,8 @@ abstract class Horde_Alarm_Storage_Base extends Horde_Test_Case
     {
         $alarm['title'] = 'Changed alarm text';
         self::$alarm->set($alarm);
+        // dummy assertion to silence PHPUnit
+        $this->assertTrue(true);
     }
 
     /**
@@ -106,10 +109,10 @@ abstract class Horde_Alarm_Storage_Base extends Horde_Test_Case
 
     /**
      * @depends testDelete
-     * @expectedException Horde_Alarm_Exception
      */
     public function testSnoozeException()
     {
+        $this->expectException('Horde_Alarm_Exception');
         self::$alarm->snooze('personalalarm', 'jane', 30);
     }
 
@@ -160,5 +163,7 @@ abstract class Horde_Alarm_Storage_Base extends Horde_Test_Case
     {
         self::$alarm->delete('noend', 'john');
         self::$alarm->delete('personalalarm', 'john');
+        // dummy assertion to silence PHPUnit
+        $this->assertTrue(true);
     }
 }

--- a/test/Horde/Alarm/Storage/NullTest.php
+++ b/test/Horde/Alarm/Storage/NullTest.php
@@ -11,6 +11,7 @@ class Horde_Alarm_Storage_NullTest extends Horde_Alarm_Storage_Base
     public function testFactory()
     {
         self::$alarm = new Horde_Alarm_Null();
+        $this->assertIsObject(self::$alarm);
     }
 
     /**
@@ -23,10 +24,10 @@ class Horde_Alarm_Storage_NullTest extends Horde_Alarm_Storage_Base
 
     /**
      * @depends testFactory
-     * @expectedException Horde_Alarm_Exception
      */
     public function testGet()
     {
+        $this->expectException('Horde_Alarm_Exception');
         $alarm = self::$alarm->get('personalalarm', 'john');
     }
 
@@ -35,6 +36,7 @@ class Horde_Alarm_Storage_NullTest extends Horde_Alarm_Storage_Base
      */
     public function testUpdate($alarm)
     {
+        $this->assertTrue(true);
     }
 
     /**

--- a/test/Horde/Alarm/Storage/ObjectTest.php
+++ b/test/Horde/Alarm/Storage/ObjectTest.php
@@ -11,5 +11,6 @@ class Horde_Alarm_Storage_ObjectTest extends Horde_Alarm_Storage_Base
     public function testFactory()
     {
         self::$alarm = new Horde_Alarm_Object();
+        $this->assertIsObject(self::$alarm);
     }
 }

--- a/test/Horde/Alarm/Storage/Sql/Base.php
+++ b/test/Horde/Alarm/Storage/Sql/Base.php
@@ -12,7 +12,7 @@ abstract class Horde_Alarm_Storage_Sql_Base extends Horde_Alarm_Storage_Base
     protected static $migrator;
     protected static $reason;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -34,7 +34,7 @@ abstract class Horde_Alarm_Storage_Sql_Base extends Horde_Alarm_Storage_Base
         self::$migrator->up();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         if (self::$migrator) {
             self::$migrator->down();
@@ -45,7 +45,7 @@ abstract class Horde_Alarm_Storage_Sql_Base extends Horde_Alarm_Storage_Base
         self::$db = self::$migrator = null;
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!self::$db) {
             $this->markTestSkipped(self::$reason);
@@ -56,6 +56,7 @@ abstract class Horde_Alarm_Storage_Sql_Base extends Horde_Alarm_Storage_Base
     public function testFactory()
     {
         self::$alarm = new Horde_Alarm_Sql(array('db' => self::$db, 'charset' => 'UTF-8'));
+        $this->assertIsObject(self::$alarm);
         self::$alarm->initialize();
         self::$alarm->gc(true);
     }

--- a/test/Horde/Alarm/Storage/Sql/MysqlTest.php
+++ b/test/Horde/Alarm/Storage/Sql/MysqlTest.php
@@ -8,7 +8,7 @@
  */
 class Horde_Alarm_Storage_Sql_MysqlTest extends Horde_Alarm_Storage_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('mysql')) {
             self::$reason = 'No mysql extension';

--- a/test/Horde/Alarm/Storage/Sql/MysqliTest.php
+++ b/test/Horde/Alarm/Storage/Sql/MysqliTest.php
@@ -8,7 +8,7 @@
  */
 class Horde_Alarm_Storage_Sql_MysqliTest extends Horde_Alarm_Storage_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('mysqli')) {
             self::$reason = 'No mysqli extension';

--- a/test/Horde/Alarm/Storage/Sql/Oci8Test.php
+++ b/test/Horde/Alarm/Storage/Sql/Oci8Test.php
@@ -8,7 +8,7 @@
  */
 class Horde_Alarm_Storage_Sql_Oci8Test extends Horde_Alarm_Storage_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('oci8')) {
             self::$reason = 'No oci8 extension';

--- a/test/Horde/Alarm/Storage/Sql/Pdo/MysqlTest.php
+++ b/test/Horde/Alarm/Storage/Sql/Pdo/MysqlTest.php
@@ -8,7 +8,7 @@
  */
 class Horde_Alarm_Storage_Sql_Pdo_MysqlTest extends Horde_Alarm_Storage_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('pdo') ||
             !in_array('mysql', PDO::getAvailableDrivers())) {

--- a/test/Horde/Alarm/Storage/Sql/Pdo/PgsqlTest.php
+++ b/test/Horde/Alarm/Storage/Sql/Pdo/PgsqlTest.php
@@ -8,7 +8,7 @@
  */
 class Horde_Alarm_Storage_Sql_Pdo_PgsqlTest extends Horde_Alarm_Storage_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('pdo') ||
             !in_array('pgsql', PDO::getAvailableDrivers())) {

--- a/test/Horde/Alarm/Storage/Sql/Pdo/SqliteTest.php
+++ b/test/Horde/Alarm/Storage/Sql/Pdo/SqliteTest.php
@@ -8,7 +8,7 @@
  */
 class Horde_Alarm_Storage_Sql_Pdo_SqliteTest extends Horde_Alarm_Storage_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $factory_db = new Horde_Test_Factory_Db();
 


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-alarm/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Add 1012_php8.2.patch. Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-alarm/-/blob/debian-sid/debian/patches/1012_php8.2.patch
